### PR TITLE
Add go install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ brew tap sho0pi/homebrew-tap
 brew install tickli
 ```
 
+### Using Go
+
+```bash
+go install github.com/sho0pi/tickli@latest
+```
+
 ### Download from Releases
 
 You can also download prebuilt binaries from the [GitHub releases page](https://github.com/Sho0pi/tickli/releases).


### PR DESCRIPTION
## Summary
- Add `go install` as an installation method in the README

## Test plan
- [ ] Verify `go install github.com/sho0pi/tickli@latest` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)