### PR TITLE
Document config.yaml settings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ tickli task complete <task-id>
 | `tickli task show`     | View task details                   |
 | `tickli task complete` | Mark a task as complete             |
 
+## Configuration
+
+Tickli stores its configuration at `~/.config/tickli/config.yaml` (following the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/)).
+
+| Key                     | Type   | Default     | Description                                      |
+| ----------------------- | ------ | ----------- | ------------------------------------------------ |
+| `default_project_id`    | string | `""`        | Default project ID used when no project is specified |
+| `default_project_color` | string | `"#FF1111"` | Default color for newly created projects         |
+
+You can set the default project interactively with `tickli project use`.
+
+OAuth credentials are stored separately at `~/.local/share/tickli/token`.
+
 ## Interactive TUI Experience (Coming Soon!)
 
 ![Tickli TUI Demo](assets/tickli-tui-demo.gif)


### PR DESCRIPTION
## Summary
- Add Configuration section to README documenting all `config.yaml` keys
- Document `default_project_id` and `default_project_color` with types and defaults
- Note the token storage location

## Test plan
- [ ] Review rendered README for correct formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)